### PR TITLE
Clang C++14

### DIFF
--- a/include/flags/flags.hpp
+++ b/include/flags/flags.hpp
@@ -14,7 +14,9 @@
 namespace flags {
 
 
-constexpr struct empty_t{} empty;
+constexpr struct empty_t {
+    constexpr empty_t() noexcept {}
+} empty;
 
 
 template <class E> struct flags {


### PR DESCRIPTION
Hi

the first change fixes a compile error with clang 3.6.0.

the second initializes the flags to 0
