### PR TITLE
Fix clang compilation warning

### DIFF
--- a/include/flags/iterator.hpp
+++ b/include/flags/iterator.hpp
@@ -55,7 +55,7 @@ public:
 
 
 private:
-  template <class E_> friend class flags;
+  template <class E_> friend struct flags;
 
   using impl_type = typename flags_type::impl_type;
 


### PR DESCRIPTION
enum_flags/iterator.hpp:58:30: class template 'flags' was previously declared as a struct template [-Wmismatched-tags]

=> Change class to struct to suppress the warning here:
  template <class E_> friend class flags;

See
https://github.com/grisumbras/enum-flags/blob/e988c32bca02706327314a142da8d828672fc2f2/include/flags/flagsfwd.hpp#L5