### PR TITLE
Make the implicit narrowing cast explicit in bitwise operators for non-int underlying types

### DIFF
--- a/include/flags/flags.hpp
+++ b/include/flags/flags.hpp
@@ -140,15 +140,15 @@ public:
   }
 
   friend constexpr flags operator|(flags f1, flags f2) noexcept {
-    return flags{f1.val_ | f2.val_};
+    return flags{static_cast<impl_type>(f1.val_ | f2.val_)};
   }
 
   friend constexpr flags operator&(flags f1, flags f2) noexcept {
-    return flags{f1.val_ & f2.val_};
+    return flags{static_cast<impl_type>(f1.val_ & f2.val_)};
   }
 
   friend  constexpr flags operator^(flags f1, flags f2) noexcept {
-    return flags{f1.val_ ^ f2.val_};
+    return flags{static_cast<impl_type>(f1.val_ ^ f2.val_)};
   }
 
 

--- a/test/Jamroot
+++ b/test/Jamroot
@@ -3,6 +3,7 @@ import testing ;
 
 project flags_tests
   : requirements <warnings>all
+                 <warnings-as-errors>on
                  <cxxflags>-std=c++11
                  <include>../include/
   : default-build <variant>release

--- a/test/common.hpp
+++ b/test/common.hpp
@@ -11,4 +11,10 @@ ALLOW_FLAGS_FOR_ENUM(Enum)
 using Enums = flags::flags<Enum>;
 
 
+enum class SmallEnum : unsigned char {SmallOne = 1, SmallTwo = 2, SmallFour = 4, SmallEight = 8};
+ALLOW_FLAGS_FOR_ENUM(SmallEnum)
+
+using SmallEnums = flags::flags<SmallEnum>;
+
+
 #endif // ENUM_CLASS_TEST_COMMON_HPP

--- a/test/should-compile.cpp
+++ b/test/should-compile.cpp
@@ -145,3 +145,9 @@ constexpr bool cf1 = ec1.empty();
 constexpr Enums::size_type cf2 = ec1.max_size();
 constexpr Enums::iterator cf3 = ec1.find(Enum::One);
 constexpr Enums::size_type cf4 = ec1.count(Enum::One);
+
+// non-int underlying type with bitwise operators
+constexpr SmallEnums s1(SmallEnum::SmallOne);
+constexpr auto s2 = s1 | s1;
+constexpr auto s3 = s1 & s1;
+constexpr auto s4 = s1 ^ s1;


### PR DESCRIPTION
Using for instance ``unsigned char`` as a base type for the enum results in a warning about a narrowing cast in the bitwise operator implementations. This pull request includes a failing test case and a fix making the cast explicit.

Side effect: the ``<warnings-as-errors>on`` is added to the build options for the test cases.