### PR TITLE
Fix MSVC compiler errors.

### DIFF
--- a/include/flags/flags.hpp
+++ b/include/flags/flags.hpp
@@ -15,7 +15,7 @@ namespace flags {
 
 
 constexpr struct empty_t {
-  constexpr empty_t() noexcept {}
+  constexpr empty_t() noexcept = default;
 } empty;
 
 
@@ -164,11 +164,11 @@ public:
   }
 
 
-  constexpr explicit operator std::bitset<bit_size()>() const noexcept {
+  constexpr explicit operator std::bitset<flags<E>::bit_size()>() const noexcept {
     return to_bitset();
   }
 
-  constexpr std::bitset<bit_size()> to_bitset() const noexcept {
+  constexpr std::bitset<flags<E>::bit_size()> to_bitset() const noexcept {
     return {val_};
   }
 


### PR DESCRIPTION
Fixes are necessary to work with VS.

First change is reported as bug in https://developercommunity.visualstudio.com/content/problem/203294/constexpr-struct-does-not-compile.html

Second isn't.