### PR TITLE
Fix MSVC warning (error) C4800

### DIFF
--- a/include/flags/flags.hpp
+++ b/include/flags/flags.hpp
@@ -93,7 +93,7 @@ public:
   { insert(b, e); }
 
 
-  constexpr explicit operator bool() const noexcept { return val_; }
+  constexpr explicit operator bool() const noexcept { return val_ != 0; }
 
   constexpr bool operator!() const noexcept { return !val_; }
 


### PR DESCRIPTION
I see following error while using the library with Unreal Engine 4.22 and VS2019.
```
1>D:\dev\swst\pkg\e3\b9\fd04\src\sdir\include\flags/flags.hpp(96): error C4800: Implicit conversion from 'const unsigned int' to bool. Possible information loss
1>  D:\dev\swst\pkg\e3\b9\fd04\src\sdir\include\flags/flags.hpp(96): note: consider using explicit cast or comparison to 0 to avoid this warning
1>  D:\dev\swst\pkg\e3\b9\fd04\src\sdir\include\flags/flags.hpp(30): note: see declaration of 'flags::flags<CurrentPathScope>::impl_type'
1>  D:\dev\swst\pkg\e3\b9\fd04\src\sdir\include\flags/flags.hpp(96): note: while compiling class template member function 'flags::flags<CurrentPathScope>::operator bool(void) noexcept const'
1>  D:\dev\primitives\src\filesystem\include\primitives/filesystem.h(147): note: see reference to function template instantiation 'flags::flags<CurrentPathScope>::operator bool(void) noexcept const' being compiled
1>  D:\dev\primitives\src\filesystem\include\primitives/filesystem.h(147): note: see reference to class template instantiation 'flags::flags<CurrentPathScope>' being compiled
1>  C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.20.27404\INCLUDE\filesystem(2071): note: see reference to class template instantiation 'std::chrono::time_point<std::filesystem::_File_time_clock,std::filesystem::_File_time_clock::duration>' being compiled
1>  C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.20.27404\INCLUDE\xstring(1675): note: see reference to class template instantiation 'std::basic_string_view<wchar_t,std::char_traits<wchar_t>>' being compiled
```